### PR TITLE
add hidden pin indicator for configured demux if children are hidden

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractFBNElementEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/AbstractFBNElementEditPart.java
@@ -466,7 +466,7 @@ public abstract class AbstractFBNElementEditPart extends AbstractPositionableEle
 		return elements;
 	}
 
-	private List<Object> getPinIndicators(final boolean input, final boolean output) {
+	protected List<Object> getPinIndicators(final boolean input, final boolean output) {
 		final List<Object> indicators = new ArrayList<>(2);
 		if (input) {
 			if (inputPinIndicator == null) {

--- a/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/DemultiplexerEditPart.java
+++ b/plugins/org.eclipse.fordiac.ide.application/src/org/eclipse/fordiac/ide/application/editparts/DemultiplexerEditPart.java
@@ -13,15 +13,48 @@
 
 package org.eclipse.fordiac.ide.application.editparts;
 
+import java.util.List;
+
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.fordiac.ide.model.data.StructuredType;
 import org.eclipse.fordiac.ide.model.libraryElement.Demultiplexer;
+import org.eclipse.fordiac.ide.model.libraryElement.VarDeclaration;
 
 public class DemultiplexerEditPart extends AbstractStructManipulatorEditPart {
-	public DemultiplexerEditPart() {
-		super();
-	}
 
 	@Override
 	public Demultiplexer getModel() {
 		return (Demultiplexer) super.getModel();
+	}
+
+	@Override
+	protected List<Object> getModelChildren() {
+		final List<Object> children = super.getModelChildren();
+		if (getModel().isIsConfigured() && isTopLevelPinHidden()) {
+			children.addAll(getPinIndicators(false, true));
+		}
+		return children;
+	}
+
+	private boolean isTopLevelPinHidden() {
+		if (getModel().getDataType() instanceof final StructuredType struct) {
+			final EList<VarDeclaration> topLevelChildren = struct.getMemberVariables();
+			final EList<VarDeclaration> visibleChildren = getModel().getMemberVars();
+			if (topLevelChildren.size() > visibleChildren.size()) {
+				return true;
+			}
+			return compareVisibleChildrenNames(topLevelChildren, visibleChildren);
+		}
+		return false;
+	}
+
+	private static boolean compareVisibleChildrenNames(final EList<VarDeclaration> topLevelChildren,
+			final EList<VarDeclaration> visibleChildren) {
+		for (final VarDeclaration structVar : topLevelChildren) {
+			if (visibleChildren.stream().noneMatch(visibleVar -> structVar.getName().equals(visibleVar.getName()))) {
+				return true;
+			}
+		}
+		return false;
 	}
 }


### PR DESCRIPTION
When a struct has additional pins to show, the flag is shown like for FBs with hidden pins.